### PR TITLE
German and Lithuanian fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,7 @@
         "*://*.parkrun.ie/*/results/*",
         "*://*.parkrun.it/*/results/*",
         "*://*.parkrun.jp/*/results/*",
+        "*://*.parkrun.lt/*/results/*",
         "*://*.parkrun.my/*/results/*",
         "*://*.parkrun.no/*/results/*",
         "*://*.parkrun.org.uk/*/results/*",

--- a/src/script.js
+++ b/src/script.js
@@ -388,7 +388,7 @@ function extractMeta(finishers) {
     if (finisher.achievement) {
       meta.achievement[finisher.achievement] = (meta.achievement[finisher.achievement] ?? 0) + 1;
 
-      const firstTimer = ["First Timer!", "Første gang!", "Première perf' !", "Erstläufer!", "Nieuwe loper!", "Ensikertalainen!", "Prima volta!", "初参加!", "Debiutant", "Debut!"];
+      const firstTimer = ["First Timer!", "Første gang!", "Erstteilnahme!", "Première perf' !", "Erstläufer!", "Nieuwe loper!", "Ensikertalainen!", "Prima volta!", "初参加!", "Debiutant", "Debut!"];
       const newPB = ["New PB!", "Neue PB!", "Meilleure perf' !", "Nieuw PR!", "Ny PB!", "Oma ennätys!", "Nuovo PB!", "自己ベスト!", "Nowy PB!", "Nytt PB!"];
 
       // uk, at, de, nl, dk, fi, fr, jp, no, pl, se

--- a/src/script.js
+++ b/src/script.js
@@ -354,7 +354,6 @@ function extractMeta(finishers) {
   meta.vols = {};
   meta.ageGrades = {};
   meta.ages = {};
-  meta.firstTimer = { male: 0, female: 0, unknown: 0 };
   meta.first = { here: 0, anywhere: 0 };
   meta.pb = { male: 0, female: 0, unknown: 0 };
   meta.milestones = {};
@@ -394,7 +393,6 @@ function extractMeta(finishers) {
       // uk, at, de, nl, dk, fi, fr, jp, no, pl, se
 
       if (firstTimer.includes(finisher.achievement)) {
-        meta.firstTimer[finisher.gender] = meta.firstTimer[finisher.gender] + 1 ?? 1;
         if (finisher.runs === '1') {
           meta.first.anywhere++;
         } else {

--- a/src/script.js
+++ b/src/script.js
@@ -362,8 +362,8 @@ function extractMeta(finishers) {
   meta.milestones.total = 0;
 
   const genderTerms = {
-    female: ["Female", "Kvinna", "Kvinde", "Kobieta", "Femme", "Frau", "Weiblich", "Naiset", "Vrouw", "Nainen", "Donna", "女子", "Kobieta", "Kvinne"],
-    male: ["Male", "Man", "Mann", "Mand", "Männlich", "Homme", "Miehet", "Mężczyzna", "男子"]
+    female: ["Female", "Kvinna", "Kvinde", "Kobieta", "Femme", "Frau", "Weiblich", "Naiset", "Vrouw", "Nainen", "Donna", "女子", "Kobieta", "Kvinne", "Moteris"],
+    male: ["Male", "Man", "Mann", "Mand", "Männlich", "Homme", "Miehet", "Mężczyzna", "男子", "Vyras"]
   };
 
   for (const finisher of finishers) {
@@ -387,8 +387,8 @@ function extractMeta(finishers) {
     if (finisher.achievement) {
       meta.achievement[finisher.achievement] = (meta.achievement[finisher.achievement] ?? 0) + 1;
 
-      const firstTimer = ["First Timer!", "Første gang!", "Erstteilnahme!", "Première perf' !", "Erstläufer!", "Nieuwe loper!", "Ensikertalainen!", "Prima volta!", "初参加!", "Debiutant", "Debut!"];
-      const newPB = ["New PB!", "Neue PB!", "Meilleure perf' !", "Nieuw PR!", "Ny PB!", "Oma ennätys!", "Nuovo PB!", "自己ベスト!", "Nowy PB!", "Nytt PB!"];
+      const firstTimer = ["First Timer!", "Første gang!", "Erstteilnahme!", "Première perf' !", "Erstläufer!", "Nieuwe loper!", "Ensikertalainen!", "Prima volta!", "初参加!", "Debiutant", "Debut!", "Naujokas!"];
+      const newPB = ["New PB!", "Neue PB!", "Meilleure perf' !", "Nieuw PR!", "Ny PB!", "Oma ennätys!", "Nuovo PB!", "自己ベスト!", "Nowy PB!", "Nytt PB!", "Naujas geriausias asmeninis rezultatas!"];
 
       // uk, at, de, nl, dk, fi, fr, jp, no, pl, se
 


### PR DESCRIPTION
#### Context

Following on from #3, I thought I'd have a look at #2.
 
#### Change

See individual commits for finer details.

#### Confirmation

##### https://www.parkrun.lt/vingis/results/3/

![Screenshot 2024-11-05 at 00-22-32 rezultatai parkrun Vingis](https://github.com/user-attachments/assets/112ea45f-6b6c-41ee-bc09-4ba07c9300f8)

##### https://www.parkrun.com.de/westpark/results/200/ (addresses #2)

![Screenshot 2024-11-05 at 00-24-56 ergebnisse Westpark parkrun](https://github.com/user-attachments/assets/cdd3675c-7294-4f92-9ec2-2d0fb97e476e)
